### PR TITLE
toValuesArray without keys

### DIFF
--- a/src/Traits/CommonMutableContainerTrait.php
+++ b/src/Traits/CommonMutableContainerTrait.php
@@ -17,9 +17,21 @@ trait CommonMutableContainerTrait
         return new ArrayList($this);
     }
 
+    /**
+     * @return array
+     */
     public function toValuesArray()
     {
-        return $this->toArray();
+        $arr = [];
+        foreach ($this as $value) {
+            if ($value instanceof Iterable) {
+                $arr[] = $value->toArray();
+            } else {
+                $arr[] = $value;
+            }
+        }
+
+        return $arr;
     }
 
     public function toKeysArray()

--- a/tests/DictionaryTest.php
+++ b/tests/DictionaryTest.php
@@ -191,4 +191,12 @@ class DictionaryTest extends CollectionsTestCase
         $this->coll->addAll($data);
         $this->assertEquals($data, $this->coll->toArray());
     }
+    
+    public function testToValuesArray()
+    {
+        $dictionary = new Dictionary();
+        $dictionary->add('key1', 'value1')->add('key2', 'value2');
+        $expected = ['value1', 'value2'];
+        $this->assertEquals($expected, $dictionary->toValuesArray());
+    }
 }


### PR DESCRIPTION
If let's say we have Dictionary with one element: key -> 111:11:11 and value -> object and when we need to do toValuesArray i expect to get only values in that array but not key values array it might be another one for that purpose like toKeyValuesArray (toArray does this) to keep keys from Dictionary