### PR TITLE
Completing comparer tests

### DIFF
--- a/tests/Comparer/NumericKeyComparerTest.php
+++ b/tests/Comparer/NumericKeyComparerTest.php
@@ -16,4 +16,26 @@ class NumericKeyComparerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInternalType("int", $result);
     }
+
+    /**
+     * @test
+     */
+    public function first_is_less_than_second()
+    {
+        $comparer = new NumericKeyComparer();
+        $result = $comparer->compare(2,3);
+
+        $this->assertSame($result,1);
+    }
+
+    /**
+     * @test
+     */
+    public function first_equals_section()
+    {
+        $comparer = new NumericKeyComparer();
+        $result = $comparer->compare(2,2);
+
+        $this->assertSame($result,0);
+    }
 }

--- a/tests/Comparer/NumericKeyComparerTest.php
+++ b/tests/Comparer/NumericKeyComparerTest.php
@@ -31,7 +31,7 @@ class NumericKeyComparerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function first_equals_section()
+    public function first_equals_second()
     {
         $comparer = new NumericKeyComparer();
         $result = $comparer->compare(2,2);


### PR DESCRIPTION
This PR just adds two tests to finish out the coverage on the NumericKeyComparer Class.  

A couple screenshots to demonstrate the small change in coverage.   

**Before:** 
<img width="1154" alt="2016-08-20_2237" src="https://cloud.githubusercontent.com/assets/6137941/17835346/eb466f16-6726-11e6-8826-2dd5822d9225.png">
<img width="1153" alt="2016-08-20_22371" src="https://cloud.githubusercontent.com/assets/6137941/17835351/0b7eb57c-6727-11e6-8c0e-955fcb4a3e3a.png">

**After:**
<img width="1153" alt="2016-08-20_2240" src="https://cloud.githubusercontent.com/assets/6137941/17835356/3648669a-6727-11e6-8cc2-187c0af2aad6.png">
<img width="1147" alt="2016-08-20_2238" src="https://cloud.githubusercontent.com/assets/6137941/17835345/eb44d444-6726-11e6-99b1-533b5583f91b.png">